### PR TITLE
Don't overwrite `BUILDKITE_METAHOOK_HOOKS_PATH`, and shard `vars` by plugin configuration

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -2,12 +2,17 @@
 set -euo pipefail
 
 # If users add multiple `metahook` instances, we'll just store our `vars` in the same directory.
+# We store the `vars` in a file that is namespaced by a hash of the plugin configuration, which
+# allows us to avoid having multiple metahook instances clobber eachother.
 if [[ ! -v "BUILDKITE_METAHOOK_HOOKS_PATH" ]]; then
   export BUILDKITE_METAHOOK_HOOKS_PATH="$(mktemp -d)"
-  env | sort | grep "BUILDKITE_PLUGIN_METAHOOK" | uniq >"${BUILDKITE_METAHOOK_HOOKS_PATH}/vars"
 fi
 
-if grep -E 'BUILDKITE_PLUGIN_METAHOOK_.+(\.BAT|\.CMD)=' "${BUILDKITE_METAHOOK_HOOKS_PATH}/vars"; then
+PLUGIN_CONFIG_HASH=$(cksum <<<"${BUILDKITE_PLUGIN_CONFIGURATION}" | awk '{ print $1 }')
+VARS_FILENAME="vars-${PLUGIN_CONFIG_HASH}"
+env | sort | grep "BUILDKITE_PLUGIN_METAHOOK" | uniq >"${BUILDKITE_METAHOOK_HOOKS_PATH}/${VARS_FILENAME}"
+
+if grep -E 'BUILDKITE_PLUGIN_METAHOOK_.+(\.BAT|\.CMD)=' "${BUILDKITE_METAHOOK_HOOKS_PATH}/${VARS_FILENAME}"; then
   echo "Sorry, we had to remove Windows Batch file support in 0.4.0."
   echo "Please refer to https://github.com/improbable-eng/metahook-buildkite-plugin/tree/master/changelog.md#0.4.0"
   echo ""

--- a/hooks/environment
+++ b/hooks/environment
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BUILDKITE_METAHOOK_HOOKS_PATH="$(mktemp -d)"
-export BUILDKITE_METAHOOK_HOOKS_PATH
-env | sort | grep "BUILDKITE_PLUGIN_METAHOOK" | uniq >"${BUILDKITE_METAHOOK_HOOKS_PATH}/vars"
+# If users add multiple `metahook` instances, we'll just store our `vars` in the same directory.
+if [[ ! -v "BUILDKITE_METAHOOK_HOOKS_PATH" ]]; then
+  export BUILDKITE_METAHOOK_HOOKS_PATH="$(mktemp -d)"
+  env | sort | grep "BUILDKITE_PLUGIN_METAHOOK" | uniq >"${BUILDKITE_METAHOOK_HOOKS_PATH}/vars"
+fi
 
 if grep -E 'BUILDKITE_PLUGIN_METAHOOK_.+(\.BAT|\.CMD)=' "${BUILDKITE_METAHOOK_HOOKS_PATH}/vars"; then
   echo "Sorry, we had to remove Windows Batch file support in 0.4.0."

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+PLUGIN_CONFIG_HASH=$(cksum <<<"${BUILDKITE_PLUGIN_CONFIGURATION}" | awk '{ print $1 }')
+VARS_FILENAME="vars-${PLUGIN_CONFIG_HASH}"
 cleanup() {
-  rm -rf "${BUILDKITE_METAHOOK_HOOKS_PATH}"
+  # Delete our `vars` directory, then if the directory itself is empty, delete that too
+  rm -rf "${BUILDKITE_METAHOOK_HOOKS_PATH}/${VARS_FILENAME}"
+  rmdir "${BUILDKITE_METAHOOK_HOOKS_PATH}" 2>/dev/null || true
 }
 trap cleanup EXIT
 

--- a/hooks/run-hook.sh
+++ b/hooks/run-hook.sh
@@ -5,7 +5,9 @@ hook_name="${1:?1st arg needs to be hook name}"
 upperd="$(echo "${hook_name}" | tr "[:lower:]" "[:upper:]" | sed "s:-:_:")"
 var_name="BUILDKITE_PLUGIN_METAHOOK_${upperd}"
 
-if grep -q "${var_name}" <"${BUILDKITE_METAHOOK_HOOKS_PATH}/vars"; then
+PLUGIN_CONFIG_HASH=$(cksum <<<"${BUILDKITE_PLUGIN_CONFIGURATION}" | awk '{ print $1 }')
+VARS_FILENAME="vars-${PLUGIN_CONFIG_HASH}"
+if grep -q "${var_name}" <"${BUILDKITE_METAHOOK_HOOKS_PATH}/${VARS_FILENAME}"; then
   hook_file="${BUILDKITE_METAHOOK_HOOKS_PATH}/${hook_name}"
 
   echo "#\!/usr/bin/env bash" >"${hook_file}"


### PR DESCRIPTION
## Changes

If we have multiple `metahook` instances, let's not generate multiple temporary directories; instead just create one (and only dump the environment variables once).  We also shard the `vars` file by the plugin configuration (calculating a hash using the standard `cksum` utility) so that you can have multiple `metahook` instances each with their own configuration (which is implicitly stored in the `vars` file).

I'm not sure why the `vars` file is created at all, as it seems it could be dynamically probed with `[[ -v "BUILDKITE_PLUGIN_METAHOOK_${upperd}" ]]` instead of using the `grep` on the `vars` file (since the variables should be live in the environment when the hook is actually executed), but I kept the current behavior.

## Verification

This fixed an issue with multiple `metahook` instances in a pipeline of mine.