### PR TITLE
Use `dirname` instead of trimming on `/`

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -12,4 +12,4 @@ if grep -E 'BUILDKITE_PLUGIN_METAHOOK_.+(\.BAT|\.CMD)=' "${BUILDKITE_METAHOOK_HO
   exit 1
 fi
 
-"${BASH_SOURCE%/*}/run-hook.sh" "$(basename "${BASH_SOURCE[0]}")"
+"$(dirname "${BASH_SOURCE[0]}")/run-hook.sh" "$(basename "${BASH_SOURCE[0]}")"

--- a/hooks/post-artifact
+++ b/hooks/post-artifact
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-"${BASH_SOURCE%/*}/run-hook.sh" "$(basename "${BASH_SOURCE[0]}")"
+"$(dirname "${BASH_SOURCE}")/run-hook.sh" "$(basename "${BASH_SOURCE[0]}")"

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-"${BASH_SOURCE%/*}/run-hook.sh" "$(basename "${BASH_SOURCE[0]}")"
+"$(dirname "${BASH_SOURCE}")/run-hook.sh" "$(basename "${BASH_SOURCE[0]}")"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-"${BASH_SOURCE%/*}/run-hook.sh" "$(basename "${BASH_SOURCE[0]}")"
+"$(dirname "${BASH_SOURCE}")/run-hook.sh" "$(basename "${BASH_SOURCE[0]}")"

--- a/hooks/pre-artifact
+++ b/hooks/pre-artifact
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-"${BASH_SOURCE%/*}/run-hook.sh" "$(basename "${BASH_SOURCE[0]}")"
+"$(dirname "${BASH_SOURCE}")/run-hook.sh" "$(basename "${BASH_SOURCE[0]}")"

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-"${BASH_SOURCE%/*}/run-hook.sh" "$(basename "${BASH_SOURCE[0]}")"
+"$(dirname "${BASH_SOURCE}")/run-hook.sh" "$(basename "${BASH_SOURCE[0]}")"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-"${BASH_SOURCE%/*}/run-hook.sh" "$(basename "${BASH_SOURCE[0]}")"
+"$(dirname "${BASH_SOURCE}")/run-hook.sh" "$(basename "${BASH_SOURCE[0]}")"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -6,4 +6,4 @@ cleanup() {
 }
 trap cleanup EXIT
 
-"${BASH_SOURCE%/*}/run-hook.sh" "$(basename "${BASH_SOURCE[0]}")"
+"$(dirname "${BASH_SOURCE}")/run-hook.sh" "$(basename "${BASH_SOURCE[0]}")"


### PR DESCRIPTION
## Changes

When running on Windows, buildkite can provide backslash-separated paths for the script name, causing the variable substitution here to fail to trim off the basename of the invoked hook file.  This changes the hooks to instead use `dirname`, which on these windows systems works with both forward and backward slash separated names.

## Verification

I integrated this change into a buildkite plugin with a test suite that runs on Linux, macOS and Windows, and [it worked on all three operating systems](https://buildkite.com/julialang/julia-buildkite-plugin/builds/83).
